### PR TITLE
Add possibility to specify custom erlangHome path

### DIFF
--- a/lib/alchemide/extend.js
+++ b/lib/alchemide/extend.js
@@ -1,0 +1,52 @@
+module.exports = function extend() {
+ var options, name, src, copy, copyIsArray, clone,
+   target = arguments[0],
+   i = 1,
+   length = arguments.length,
+   deep = false;
+
+ // Handle a deep copy situation
+ if (typeof target === 'boolean') {
+   deep = target;
+   target = arguments[1] || {};
+   // skip the boolean and the target
+   i = 2;
+ } else if ((typeof target !== 'object' && typeof target !== 'function') || target == null) {
+   target = {};
+ }
+
+ for (; i < length; ++i) {
+   options = arguments[i];
+   // Only deal with non-null/undefined values
+   if (options != null) {
+     // Extend the base object
+     for (name in options) {
+       src = target[name];
+       copy = options[name];
+
+       // Prevent never-ending loop
+       if (target !== copy) {
+         // Recurse if we're merging plain objects or arrays
+         if (deep && copy && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
+           if (copyIsArray) {
+             copyIsArray = false;
+             clone = src && isArray(src) ? src : [];
+           } else {
+             clone = src && isPlainObject(src) ? src : {};
+           }
+
+           // Never move original objects, clone them
+           target[name] = extend(deep, clone, copy);
+
+         // Don't bring in undefined values
+         } else if (typeof copy !== 'undefined') {
+           target[name] = copy;
+         }
+       }
+     }
+   }
+ }
+
+ // Return the modified object
+ return target;
+};

--- a/lib/alchemide/wrapper.coffee
+++ b/lib/alchemide/wrapper.coffee
@@ -1,5 +1,6 @@
 IS_ELIXIR = false
 
+extend = require "./extend"
 autocomplete = "autocompleter/autocomplete.exs"
 Process = require("atom").BufferedProcess
 
@@ -7,9 +8,11 @@ spawn = require('child_process').spawn
 path = require 'path'
 fs = require 'fs'
 
+
 out = null
 inp  = null
 projectPaths = null;
+lastError = null;
 
 error = (e) -> atom.notifications.addError("Woops. Something went bananas \n Error: #{e}") #console.log("Err: #{e}")
 
@@ -17,25 +20,44 @@ exports.init = (pP) ->
   projectPaths = pP;
   p = path.join(__dirname, autocomplete)
   array = projectPaths
-  stderr = (e) -> #console.log("Err: #{e}")
-  exit = (e) -> console.log("CLOSED #{e}"); exports.init(projectPaths)
+  stderr = (e) -> lastError = e #console.log("Err: #{e}")
+  exit = (e) -> console.error("CLOSED #{e}, Last Error: #{lastError}"); exports.init(projectPaths)
 
   array.push(p)
   name = if IS_ELIXIR then 'autocomplete-elixir' else 'autocomplete-erlang'
   setting = atom.config.get("#{name}.elixirPath").replace(/elixir$/,"")
   command = path.join ( setting || "") , "elixir"
-  console.log(setting)
-  try
-    ac = new Process({command: command, args: array.reverse(), stderr, exit})
-  catch e
-    error e
 
+  #line 1  #line 2
+
+  erlPath = atom.config.get("#{name}.erlangHome").trim()
+  env = if erlPath
+      extend({
+        ERL_HOME: erlPath,
+        ERL_PATH: path.join(erlPath, 'erl')
+      }, process.env)
+  else
+      process.env
+  options = {
+    env: env
+  }
+
+  console.log(setting)
+  ac = new Process({
+    command: command,
+    options: options,
+    args: array.reverse(), stderr, exit, stdout: ->})
+  unless ac.process then exports.init(pP)
 
   out = ac.process.stdout
   inp = ac.process.stdin
 
+
+
 exports.getAutocompletion = (prefix, cb) ->
-  unless inp then exports.init(projectPaths)
+  unless inp
+    exports.init(projectPaths)
+    return
   if prefix.trim().length < 1
     cb()
     return
@@ -46,7 +68,9 @@ exports.getAutocompletion = (prefix, cb) ->
     cb({one, multi: multi.split(";").filter((a) -> a.trim())})
 
 exports.loadFile =          (path,   cb = (->)) ->
-  unless inp then exports.init(projectPaths)
+  unless inp
+    exports.init(projectPaths)
+    return
   unless /.ex$/.test(path)
     cb()
     return

--- a/lib/autocomplete-erlang.coffee
+++ b/lib/autocomplete-erlang.coffee
@@ -6,6 +6,10 @@ module.exports =
       type: 'string'
       default: ""
       description: "Absolute path to elixir executable (essential for MacOS)"
+    erlangHome:
+      type: 'string'
+      default: ""
+      description: "Absolute path to erlang bin directory (essential for MacOS)"
 
 
   rsenseProvider: null


### PR DESCRIPTION
**Problem:**
It is not possible to select different Erlang runtime than system's default.
It is possible in autocomplete-elixir so I believe it wasn't (back?)ported here.

**Solution:**
Backport changes from autocomplete-elixir.

Best to be implemented together with: wende/autocomplete-elixir/pull/56
